### PR TITLE
Allow scan_range to be modified in UDS_RCStartEnumerator

### DIFF
--- a/scapy/contrib/automotive/uds_scan.py
+++ b/scapy/contrib/automotive/uds_scan.py
@@ -675,8 +675,6 @@ class UDS_RCStartEnumerator(UDS_RCEnumerator):
         # type: (Any) -> Iterable[Packet]
         if "type_list" in kwargs:
             raise KeyError("'type_list' already set in kwargs.")
-        if "scan_range" in kwargs:
-            raise KeyError("'scan_range' set in kwargs.")
         kwargs["type_list"] = [1]
         return super(UDS_RCStartEnumerator, self). \
             _get_initial_requests(**kwargs)


### PR DESCRIPTION
`scan_range` should be also setable for the `RCStartEnumerator`. Only the `type_list` must not be set.